### PR TITLE
Add support for `redactedFields`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -158,7 +158,7 @@ function register (server, options = {}) {
             if (typeof payload[p] !== 'object') {
               payload[p] = '***';
             }
-            return payload && payload[p];
+            return payload[p];
           }, payload);
         });
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -146,7 +146,7 @@ function register (server, options = {}) {
         /* $lab:coverage:on$ */
       };
 
-      // Just override the arra of provided fields with '***'
+      // Just override the array of provided fields with '***'
       // Nested properties can be provided using dots like:
       // ['req.headers.x-authorization']
       if (redactedFields.length) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -152,7 +152,7 @@ function register (server, options = {}) {
       if (redactedFields.length) {
         redactedFields.forEach((f) => {
           f.split('.').reduce((payload, p) => {
-            if (typeof payload[p] === 'undefined') {
+            if (payload[p] === undefined) {
               return false;
             }
             if (typeof payload[p] !== 'object') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,13 +42,15 @@ function register (server, options = {}) {
     level = 'info',
     logger = null,  // TODO(cjihrig): Support creating the logger internally.
     logLevelMap = {},
-    onError = undefined
+    onError = undefined,
+    redactedFields = []
   } = options;
 
   validateArrayOfStrings(events, 'events');
   validateArrayOfStrings(ignoreChannels, 'ignoreChannels');
   validateArrayOfStrings(ignorePaths, 'ignorePaths');
   validateArrayOfStrings(ignoreTags, 'ignoreTags');
+  validateArrayOfStrings(redactedFields, 'redactedFields');
   validateLogLevel(defaultLevel, 'defaultLevel');
   validateLogLevel(level, 'level');
 
@@ -143,6 +145,23 @@ function register (server, options = {}) {
         responseTime: (info.completed !== undefined ? info.completed : info.responded) - info.received
         /* $lab:coverage:on$ */
       };
+
+      // Just override the arra of provided fields with '***'
+      // Nested properties can be provided using dots like:
+      // ['req.headers.x-authorization']
+      if (redactedFields.length) {
+        redactedFields.forEach((f) => {
+          f.split('.').reduce((payload, p) => {
+            if (typeof payload[p] === 'undefined') {
+              return false;
+            }
+            if (typeof payload[p] !== 'object') {
+              payload[p] = '***';
+            }
+            return payload && payload[p];
+          }, payload);
+        });
+      }
 
       logger[defaultLevel]('request completed', payload, additionalFields);
     });


### PR DESCRIPTION
An array of field names to redact can be provided using the `redactedFields` property, which should be an array of strings of the form: `['foo', 'req.headers.x-auth', 'res.whatever']`.
The value for those properties, when present, will be replaced with string `'***'` allowing hiding such values from logs.